### PR TITLE
feat: add npc tab to player view and fix master npc management

### DIFF
--- a/src/components/PlayerNPCList.tsx
+++ b/src/components/PlayerNPCList.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Users } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+
+interface NPC {
+  id: string;
+  name: string;
+  image: string | null;
+  data: Record<string, unknown> | null;
+}
+
+interface PlayerNPCListProps {
+  campaign: { id: string };
+}
+
+const PlayerNPCList = ({ campaign }: PlayerNPCListProps) => {
+  const [npcs, setNpcs] = useState<NPC[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchNPCs = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('npcs')
+          .select('*')
+          .eq('campaign_id', campaign.id)
+          .order('created_at');
+
+        if (error) {
+          console.error('Error fetching NPCs:', error);
+          return;
+        }
+
+        setNpcs(data as NPC[] || []);
+      } catch (err) {
+        console.error('Error in fetchNPCs:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNPCs();
+  }, [campaign.id]);
+
+  return (
+    <Card className="tavern-card text-amber-100">
+      <CardHeader>
+        <CardTitle className="text-xl text-amber-100">NPCs</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="text-center py-8">
+            <p className="text-amber-200">Loading NPCs...</p>
+          </div>
+        ) : npcs.length === 0 ? (
+          <div className="text-center py-8">
+            <Users className="h-16 w-16 text-amber-400 mx-auto mb-4" />
+            <p className="text-amber-200">No NPCs available.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {npcs.map((npc) => (
+              <div key={npc.id} className="flex flex-col items-center space-y-2">
+                <Avatar className="h-20 w-20">
+                  <AvatarImage src={npc.image} />
+                  <AvatarFallback className="bg-amber-600 text-amber-100 text-xl">
+                    {npc.name.charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-amber-100">{npc.name}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PlayerNPCList;

--- a/src/pages/MasterView.tsx
+++ b/src/pages/MasterView.tsx
@@ -176,7 +176,7 @@ const MasterView = () => {
           </TabsContent>
 
           <TabsContent value="npcs">
-            <NPCManager campaign={campaign} updateCampaign={updateCampaign} />
+            <NPCManager campaign={campaign} />
           </TabsContent>
 
           <TabsContent value="annotations">

--- a/src/pages/PlayerView.tsx
+++ b/src/pages/PlayerView.tsx
@@ -4,13 +4,14 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { User, Dice6, Scroll, LogOut, FileText, Image } from 'lucide-react';
+import { User, Dice6, Scroll, LogOut, FileText, Image, Users } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/useAuth';
 import VerticalCharacterSheet from '@/components/VerticalCharacterSheet';
 import DiceRollerEnhanced from '@/components/DiceRollerEnhanced';
 import PlayerAnnotationsManager from '@/components/PlayerAnnotationsManager';
 import PlayerMediaViewer from '@/components/PlayerMediaViewer';
+import PlayerNPCList from '@/components/PlayerNPCList';
 
 const PlayerView = () => {
   const { code } = useParams();
@@ -172,7 +173,7 @@ const PlayerView = () => {
           </div>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className={`space-y-6 ${shouldUseFullPageLayout ? 'flex-1 flex flex-col' : ''}`}>
-            <TabsList className="grid w-full grid-cols-4 tavern-card flex-shrink-0">
+            <TabsList className="grid w-full grid-cols-5 tavern-card flex-shrink-0">
               <TabsTrigger value="character" className="data-[state=active]:bg-amber-700/50 data-[state=active]:text-amber-100 text-amber-200">
                 <User className="h-4 w-4 mr-2" />
                 My Character
@@ -184,6 +185,10 @@ const PlayerView = () => {
               <TabsTrigger value="media" className="data-[state=active]:bg-amber-700/50 data-[state=active]:text-amber-100 text-amber-200">
                 <Image className="h-4 w-4 mr-2" />
                 Media
+              </TabsTrigger>
+              <TabsTrigger value="npcs" className="data-[state=active]:bg-amber-700/50 data-[state=active]:text-amber-100 text-amber-200">
+                <Users className="h-4 w-4 mr-2" />
+                NPCs
               </TabsTrigger>
               <TabsTrigger value="dice" className="data-[state=active]:bg-amber-700/50 data-[state=active]:text-amber-100 text-amber-200">
                 <Dice6 className="h-4 w-4 mr-2" />
@@ -210,6 +215,10 @@ const PlayerView = () => {
 
             <TabsContent value="media">
               <PlayerMediaViewer campaign={campaign} />
+            </TabsContent>
+
+            <TabsContent value="npcs">
+              <PlayerNPCList campaign={campaign} />
             </TabsContent>
 
             <TabsContent value="dice">


### PR DESCRIPTION
## Summary
- store NPCs in Supabase and load them for masters
- add NPC list tab in player view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68965bb08ba08332b79f339f8aa3c551